### PR TITLE
add upgrade handler for v0.12.x

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -44,7 +44,7 @@ import (
 
 	"github.com/OmniFlix/omniflixhub/app/keepers"
 	"github.com/OmniFlix/omniflixhub/app/upgrades"
-	v2 "github.com/OmniFlix/omniflixhub/app/upgrades/v2"
+	v012 "github.com/OmniFlix/omniflixhub/app/upgrades/v012"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 )
 
@@ -67,7 +67,7 @@ func getGovProposalHandlers() []govclient.ProposalHandler {
 var (
 	// DefaultNodeHome default home directories for the application daemon
 	DefaultNodeHome string
-	Upgrades        = []upgrades.Upgrade{v2.Upgrade}
+	Upgrades        = []upgrades.Upgrade{v012.Upgrade}
 	Forks           []upgrades.Fork
 )
 

--- a/app/keepers/keepers.go
+++ b/app/keepers/keepers.go
@@ -415,6 +415,7 @@ func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino
 	paramsKeeper.Subspace(ibctransfertypes.ModuleName)
 	paramsKeeper.Subspace(ibchost.ModuleName)
 	paramsKeeper.Subspace(icahosttypes.SubModuleName)
+	paramsKeeper.Subspace(packetforwardtypes.ModuleName).WithKeyTable(packetforwardtypes.ParamKeyTable())
 	paramsKeeper.Subspace(alloctypes.ModuleName)
 	paramsKeeper.Subspace(onfttypes.ModuleName)
 	paramsKeeper.Subspace(marketplacetypes.ModuleName)

--- a/app/upgrades/v012/constants.go
+++ b/app/upgrades/v012/constants.go
@@ -1,17 +1,18 @@
-package v2
+package v012
 
 import (
 	"github.com/OmniFlix/omniflixhub/app/upgrades"
 	store "github.com/cosmos/cosmos-sdk/store/types"
 	icahosttypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/host/types"
+	packetforwardtypes "github.com/strangelove-ventures/packet-forward-middleware/v4/router/types"
 )
 
-const UpgradeName = "v2"
+const UpgradeName = "v0.12.x"
 
 var Upgrade = upgrades.Upgrade{
 	UpgradeName:          UpgradeName,
 	CreateUpgradeHandler: CreateUpgradeHandler,
 	StoreUpgrades: store.StoreUpgrades{
-		Added: []string{icahosttypes.StoreKey},
+		Added: []string{icahosttypes.StoreKey, packetforwardtypes.StoreKey},
 	},
 }

--- a/app/upgrades/v012/upgrades.go
+++ b/app/upgrades/v012/upgrades.go
@@ -1,4 +1,4 @@
-package v2
+package v012
 
 import (
 	"github.com/OmniFlix/omniflixhub/app/keepers"
@@ -11,6 +11,7 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	icahosttypes "github.com/cosmos/ibc-go/v4/modules/apps/27-interchain-accounts/host/types"
+	packetforwardtypes "github.com/strangelove-ventures/packet-forward-middleware/v4/router/types"
 )
 
 func CreateUpgradeHandler(
@@ -47,6 +48,17 @@ func CreateUpgradeHandler(
 		}
 
 		keepers.ICAHostKeeper.SetParams(ctx, hostParams)
+
+		// Packet Forward middleware initial params
+		keepers.PacketForwardKeeper.SetParams(ctx, packetforwardtypes.DefaultParams())
+
+		// itc campaigns migrations
+		campaigns := keepers.ItcKeeper.GetAllCampaigns(ctx)
+		for _, campaign := range campaigns {
+			claims := keepers.ItcKeeper.GetClaims(ctx, campaign.Id)
+			campaign.ClaimCount = uint64(len(claims))
+			keepers.ItcKeeper.SetCampaign(ctx, campaign)
+		}
 
 		return versionMap, nil
 	}


### PR DESCRIPTION
upgrade handler for v0.12.x upgrade
- sets ICA params
- sets PFM params 
- updates claim count to campaigns (updates added in #78)

