### PR TITLE
upgrade(v6): fix upgrade handler

### DIFF
--- a/app/modules.go
+++ b/app/modules.go
@@ -1,7 +1,5 @@
 package app
 
-// sdk v.50.x migration TODO:Eventually should get rid of this in favor of NewBasicManagerFromManager
-
 import (
 	circuittypes "cosmossdk.io/x/circuit/types"
 	"cosmossdk.io/x/nft"

--- a/app/upgrades/v6/constants.go
+++ b/app/upgrades/v6/constants.go
@@ -4,6 +4,7 @@ import (
 	store "cosmossdk.io/store/types"
 	"github.com/OmniFlix/omniflixhub/v6/app/upgrades"
 	medianodetypes "github.com/OmniFlix/omniflixhub/v6/x/medianode/types"
+	feemarkettypes "github.com/skip-mev/feemarket/x/feemarket/types"
 )
 
 const (
@@ -17,6 +18,7 @@ var Upgrade = upgrades.Upgrade{
 	StoreUpgrades: store.StoreUpgrades{
 		Added: []string{
 			medianodetypes.StoreKey,
+			feemarkettypes.StoreKey,
 		},
 		Deleted: []string{
 			GlobalFeeModuleName,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - During the version 6 upgrade, the fee market module store will now be initialized alongside the medianode store.
  - Medianode module parameters will be explicitly configured during the upgrade, including minimum deposit, deposit percentage, lease duration, deposit release period, and commission settings.

- **Chores**
  - Removed an outdated comment referencing a previous SDK migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->